### PR TITLE
Fixes #1: sysDeltaSeconds race condition.

### DIFF
--- a/registry.go
+++ b/registry.go
@@ -1,7 +1,9 @@
 package ecsgo
 
 import (
+	"math"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -27,7 +29,7 @@ type Registry struct {
 	defferredAddCmp    map[Entity][]*componentInfo
 	defferredRemoveSys []sysInfo
 	deltaSeconds       float64
-	sysDeltaSeconds    float64
+	sysDeltaSeconds    uint64
 }
 
 // New make new Registry
@@ -78,11 +80,11 @@ func (r *Registry) Release(e Entity) {
 }
 
 func (r *Registry) DeltaSeconds() float64 {
-	return r.sysDeltaSeconds
+	return math.Float64frombits(atomic.LoadUint64(&r.sysDeltaSeconds))
 }
 
 func (r *Registry) setSystemDeltaSeconds(val float64) {
-	r.sysDeltaSeconds = val
+	atomic.StoreUint64(&r.sysDeltaSeconds, math.Float64bits(val))
 }
 
 // Run run systems

--- a/system_test.go
+++ b/system_test.go
@@ -1,0 +1,10 @@
+package ecsgo
+
+import "testing"
+
+func TestRegistry_Tick_sysDeltaSecondsRace(t *testing.T) {
+	registry := New()
+	AddSystem(registry, OnTick, func(r *Registry) {})
+	AddSystem(registry, OnTick, func(r *Registry) {})
+	registry.Tick(1.0)
+}


### PR DESCRIPTION
This PR adds a test for #1, and fixes it by protecting all accesses to `Registry.sysDeltaSeconds` with `atomic`.
